### PR TITLE
push release image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,5 +28,15 @@ elifePipeline {
                 unstable_image.tag('latest').push()
             }
        }
+
+       elifeTagOnly { tagName ->
+            def releaseVersion = tagName - "v"
+
+            stage 'Push release image', {
+                def image = DockerImage.elifesciences(this, 'sciencebeam-grobid-biorxiv', commit)
+                image.tag(releaseVersion).push()
+                image.tag('latest').push()
+            }
+        }
     }
 }


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/5585

extension of #2 to push a release image (on tag builds)