### PR TITLE
fixed dl-glove-6B-50d not built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,14 +102,12 @@ end2end-test: \
 
 build-and-end2end-test-dl-no-word-embeddings:
 	$(MAKE) "GROBID_VARIANT_NAME=$(GROBID_VARIANT_NAME_DL_NO_WORD_EMBEDDINGS)" \
-		build
-		# build end2end-test stop
+		build end2end-test stop
 
 
 build-and-end2end-test-dl-glove-6b-50d:
 	$(MAKE) "GROBID_VARIANT_NAME=$(GROBID_VARIANT_NAME_DL_GLOVE_6B_50d)" \
-		build
-		# build end2end-test stop
+		build end2end-test stop
 
 
 build-and-end2end-test-all: \

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-DOCKER_COMPOSE_CI = GROBID_PORT=$(GROBID_PORT) \
+DOCKER_COMPOSE = GROBID_PORT=$(GROBID_PORT) \
 	IMAGE_TAG=$(IMAGE_TAG) \
 	GROBID_DOCKERFILE=$(GROBID_DOCKERFILE) \
 	GROBID_IMAGE_TAG_SUFFIX=$(GROBID_IMAGE_TAG_SUFFIX) \
 	docker-compose -f docker-compose.yml
-DOCKER_COMPOSE = $(DOCKER_COMPOSE_CI)
 
 DOCKER = docker
 
@@ -103,12 +102,14 @@ end2end-test: \
 
 build-and-end2end-test-dl-no-word-embeddings:
 	$(MAKE) "GROBID_VARIANT_NAME=$(GROBID_VARIANT_NAME_DL_NO_WORD_EMBEDDINGS)" \
-		build end2end-test stop
+		build
+		# build end2end-test stop
 
 
 build-and-end2end-test-dl-glove-6b-50d:
 	$(MAKE) "GROBID_VARIANT_NAME=$(GROBID_VARIANT_NAME_DL_GLOVE_6B_50d)" \
-		build end2end-test stop
+		build
+		# build end2end-test stop
 
 
 build-and-end2end-test-all: \
@@ -137,8 +138,7 @@ build-and-end2end-test-all: \
 
 
 ci-build-and-test:
-	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" \
-		build-and-end2end-test-all
+	$(MAKE) build-and-end2end-test-all
 
 
 ci-push-unstable-images:
@@ -158,4 +158,4 @@ ci-push-release-images-dryrun:
 
 
 ci-clean:
-	$(DOCKER_COMPOSE_CI) down -v
+	$(DOCKER_COMPOSE) down -v


### PR DESCRIPTION
#4 introduced dl-glove-6B-50d

but the ci process didn't actually build it. That is because the assignment `DOCKER_COMPOSE` made the variables static and were no longer changed from the default.