### PR TITLE
fixed word embeddings downloaded at runtime

### DIFF
--- a/Dockerfile.dl-glove-6B-50d
+++ b/Dockerfile.dl-glove-6B-50d
@@ -1,4 +1,4 @@
-FROM elifesciences/sciencebeam-trainer-delft-grobid_unstable:04346b26b5fa7966cef4d6ec6bba867feba52d66-cbb7e63d1b2c27c67afe591abbb23ccc95c6cfb7
+FROM elifesciences/sciencebeam-trainer-delft-grobid_unstable:04346b26b5fa7966cef4d6ec6bba867feba52d66-dee3b060495006aa9f8e1b89f6278b44231fe0cc
 
 ENV GROBID_MODELS_DIRECTORY=/opt/grobid/grobid-home/models
 ENV EMBEDDING_REGISTRY_PATH="${PROJECT_FOLDER}/embedding-registry.json"

--- a/Dockerfile.dl-no-word-embeddings
+++ b/Dockerfile.dl-no-word-embeddings
@@ -1,4 +1,4 @@
-FROM elifesciences/sciencebeam-trainer-delft-grobid_unstable:04346b26b5fa7966cef4d6ec6bba867feba52d66-cbb7e63d1b2c27c67afe591abbb23ccc95c6cfb7
+FROM elifesciences/sciencebeam-trainer-delft-grobid_unstable:04346b26b5fa7966cef4d6ec6bba867feba52d66-dee3b060495006aa9f8e1b89f6278b44231fe0cc
 
 ENV GROBID_MODELS_DIRECTORY=/opt/grobid/grobid-home/models
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,5 @@ services:
         image: elifesciences/sciencebeam-grobid-biorxiv:${IMAGE_TAG}${GROBID_IMAGE_TAG_SUFFIX:-}
         ports:
             - "${GROBID_PORT:-8070}:8070"
+        extra_hosts:
+            - github.com:127.0.0.1


### PR DESCRIPTION
This fixes the issue that embeddings were downloaded again at runtime.

This was due to `/data` being marked as volume in the base image. Therefore any additional files during build time were discarded.